### PR TITLE
Add Support for AWS Named Profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.2.4] - 2024-04-25
+
+- Support the use of AWS Named Profiles for authentication
+
 ## [0.2.3] - 2024-01-12
 
 - Fix A121 Labs bug for maxTokens parameter

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby-amazon-bedrock (0.2.3)
+    ruby-amazon-bedrock (0.2.4)
       aws-sdk-bedrockruntime (~> 1.0)
       aws-sdk-s3 (~> 1.0)
 
@@ -106,4 +106,4 @@ DEPENDENCIES
   webmock (~> 3.12)
 
 BUNDLED WITH
-   2.4.22
+   2.4.14

--- a/README.md
+++ b/README.md
@@ -63,10 +63,33 @@ client = RubyAmazonBedrock::Client.new(
 )
 ```
 
+### AWS Named Profiles
+
+You can also use [AWS Named Profiles](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-format-profile):
+
+```ruby
+client = RubyAmazonBedrock::Client.new(
+  profile: 'dev' 
+)
+```
+
+This will default to the value of the `$AWS_PROFILE` environment variable and will take precidence over key/token keys.  If for some reason you have `$AWS_PROFILE` defined in your environment _and you do not want to use it_ then you can disable by passing an empty string and specifying your region/key/secret as usual:
+
+```ruby
+client = RubyAmazonBedrock::Client.new(
+  profile: "",            # Disable named profile
+  region: "AWS_REGION",
+  access_key_id: "AWS_ACCESS_KEY_ID",
+  access_token: "AWS_SECRET_ACCESS_KEY"
+)
+```
+
 ## With Configuration
 
 ```ruby
 RubyAmazonBedrock.configure do |config|
+  # You don't need to specify these lines to default to the environment variables, these lines are provided for illustrative purposes only
+  config.profile = ENV.fetch('AWS_PROFILE', nil)
   config.region = ENV.fetch('AWS_REGION', nil)
   config.access_key_id = ENV.fetch('AWS_ACCESS_KEY_ID', nil)
   config.secret_access_key = ENV.fetch('AWS_SECRET_ACCESS_KEY', nil)

--- a/lib/amazon_bedrock.rb
+++ b/lib/amazon_bedrock.rb
@@ -13,7 +13,7 @@ module RubyAmazonBedrock
 
   # Configuration class for setting up AWS credentials and region.
   class Configuration
-    attr_accessor :region, :access_key_id, :secret_access_key
+    attr_accessor :region, :access_key_id, :secret_access_key, :profile
 
     # Initializes a new Configuration instance, loading values from
     # environment variables or setting them to nil by default so the
@@ -22,6 +22,7 @@ module RubyAmazonBedrock
       @region = ENV.fetch('AWS_REGION', nil)
       @access_key_id = ENV.fetch('AWS_ACCESS_KEY_ID', nil)
       @secret_access_key = ENV.fetch('AWS_SECRET_ACCESS_KEY', nil)
+      @profile = ENV.fetch('AWS_PROFILE', nil)
     end
   end
 

--- a/lib/amazon_bedrock/version.rb
+++ b/lib/amazon_bedrock/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RubyAmazonBedrock
-  VERSION = "0.2.3"
+  VERSION = "0.2.4"
 end

--- a/lib/bedrock_runtime/client.rb
+++ b/lib/bedrock_runtime/client.rb
@@ -14,14 +14,21 @@ module RubyAmazonBedrock
     # Initializes the AWS BedrockRuntime client.
     #
     # @note The AWS credentials and region are fetched from the environment variables.
-    def initialize(region: nil, access_key_id: nil, secret_access_key: nil)
+    def initialize(region: nil, access_key_id: nil, secret_access_key: nil, profile: nil)
       config = RubyAmazonBedrock.configuration || RubyAmazonBedrock::Configuration.new
 
-      @client = Aws::BedrockRuntime::Client.new(
-        region: region || config.region,
-        access_key_id: access_key_id || config.access_key_id,
-        secret_access_key: secret_access_key || config.secret_access_key
-      )
+      profile ||= config.profile
+      if profile.present?
+        @client = Aws::BedrockRuntime::Client.new(
+          profile: profile
+        )
+      else
+        @client = Aws::BedrockRuntime::Client.new(
+          region: region || config.region,
+          access_key_id: access_key_id || config.access_key_id,
+          secret_access_key: secret_access_key || config.secret_access_key
+        )
+      end
     end
 
     # Invokes a model using the Bedrock Runtime client.


### PR DESCRIPTION
Named profiles are helpful when you have a lot of different AWS accounts and switch between them.

This PR adds support, using the standard AWS environment variable, to allow this to work while also supporting the other configuration methods already implemented in this gem.

Also updates docs, changelog, and version bump.